### PR TITLE
fix: clarify enargus value parameter accepts Clojure values

### DIFF
--- a/src/systems/thoughtfull/argus.cljc
+++ b/src/systems/thoughtfull/argus.cljc
@@ -113,7 +113,7 @@
   ```
 
   - **`argus`** — an argus specification produced by [[argus]].
-  - **`value`** — a JSON-compatible tagged value to encode."
+  - **`value`** — a Clojure value to encode."
   [argus value]
   (enargus* (:cache argus) value))
 


### PR DESCRIPTION
Should say 'a Clojure value to encode' instead of 'a JSON-compatible tagged value to encode'.
Fixes #5.